### PR TITLE
Fixing escape sequence expansion code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 dist-newstyle/
+.hie/

--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ withLabel "test" (that registeredThese) $ observe 6.9
 
 -- Export metrics
 bytestr <- genericExport registeredThese
+```

--- a/README.md
+++ b/README.md
@@ -1,23 +1,17 @@
-# prometheus-porting
+# prometheus-port [![CircleCI](https://dl.circleci.com/status-badge/img/gh/on-ramp/prometheus-port/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/on-ramp/prometheus-port/tree/master)
 
 This library is yet another [prometheus client](https://prometheus.io/docs/instrumenting/writing_clientlibs)
 implementation, with [prometheus](https://hackage.haskell.org/package/prometheus) being a bulky
 mess of imports and [prometheus-client](https://hackage.haskell.org/package/prometheus) breaking
 referential transparency (it's still probably a better choice for smaller-sized projects).
 
-
-
 ## Library usage
 
 The interface defined in this package is an exact copy of that defined in
 [prometheus-client](https://hackage.haskell.org/package/prometheus), except:
 
-- Collection operations are all defined in typeclasses
-    (e.g. Counters and Gauges use `increment` instead of their respective `incCounter` and `incGauge`);
-
-- Metrics can be registered and exported in bulk if defined inside of a matching `Generic` datatype;
-
-Therefore...
+- Collection operations are all defined in typeclasses (e.g. Counters and Gauges use `increment` instead of their respective `incCounter` and `incGauge`),
+- and metrics can be registered and exported in bulk if defined inside of a matching `Generic` datatype.
 
 ### Using metrics as usual
 
@@ -55,7 +49,6 @@ withlabel "this" vcntr $ plus 5
 
 vcntrExported <- export vcntr
 ```
-
 
 ### Packing metrics into datatypes
 

--- a/benchmarks/Time.hs
+++ b/benchmarks/Time.hs
@@ -1,18 +1,133 @@
 module Main where
 
+import Control.DeepSeq
+import Control.Monad.IO.Class
+import qualified Data.List as List
+import Data.Ord (comparing)
 import Gauge.Main
-
-fib :: Int -> Int
-fib 0 = 0
-fib 1 = 1
-fib n = fib (n - 1) + fib (n - 2)
+import Prometheus.Internal.Pure (Bucket, Quantile)
+import qualified Prometheus.Internal.Pure as Pure
+import System.Random (initStdGen)
+import qualified System.Random as Random
 
 main :: IO ()
 main =
   defaultMain
     [ bgroup
-        "fib"
-        [ bench "10" $ whnf fib 10,
-          bench "11" $ whnf fib 11
+        "Pure"
+        [ bgroup
+            "Increment"
+            ( concat
+                [ benchIncrPure setIncrPureCounter "Counter",
+                  benchIncrPure setIncrPureGauge "Gauge"
+                ]
+            ),
+          bgroup
+            "Observe"
+            ( concat
+                [ benchObservePure setObservePureHistogram "Histogram",
+                  benchObservePure setObservePureEstimator "Estimator"
+                ]
+            ),
+          bgroup
+            "Export"
+            ( concat
+                [ benchExportPure setExportPureCounter "Counter",
+                  benchExportPure setExportPureHistogram "Histogram",
+                  benchExportPure setExportPureEstimator "Estimator"
+                ]
+            )
         ]
     ]
+  where
+    benchIncrPure ::
+      (Pure.Increment m, Pure.Extract m e, NFData m, NFData e) =>
+      IO m ->
+      String ->
+      [Benchmark]
+    benchIncrPure setM title =
+      [ env setM $ \pM ->
+          bench (title ++ ": " ++ show i) $ nf (incrementN i) pM
+        | i <- [10000, 100000]
+      ]
+      where
+        incrementN 0 m = m
+        incrementN n m = incrementN (n - 1) $ Pure.plus 1 m
+
+    benchObservePure ::
+      (Pure.Observe m, Pure.Extract m e, NFData m, NFData e) =>
+      (Int -> IO (m, [Double])) ->
+      String ->
+      [Benchmark]
+    benchObservePure setUp title =
+      [ env (setUp i) $ \ ~(m, vs) ->
+          bench (title ++ ": " ++ show i) $ nf (\m -> List.foldl' (flip Pure.observe) m vs) m
+        | i <- [1000, 10000]
+      ]
+
+    benchExportPure ::
+      (Pure.Export m, NFData m) =>
+      (Int -> IO m) ->
+      String ->
+      [Benchmark]
+    benchExportPure setUp title =
+      [ env (setUp i) $ \m ->
+          bench (title ++ ": " ++ show i) $ nf Pure.export m
+        | i <- [1000, 10000]
+      ]
+
+    setIncrPureCounter :: IO Pure.Counter
+    setIncrPureCounter = pure . force $ Pure.construct ()
+
+    setIncrPureGauge :: IO Pure.Gauge
+    setIncrPureGauge = pure . force $ Pure.construct ()
+
+    setObservePureHistogram :: Int -> IO (Pure.Histogram, [Double])
+    setObservePureHistogram n = do
+      let buckets = Pure.defBuckets
+          histo = force $ Pure.construct buckets
+      values <- genHistoValues n buckets
+      return (histo, values)
+
+    setObservePureEstimator :: Int -> IO (Pure.Estimator, [Double])
+    setObservePureEstimator n = do
+      let qts = Pure.defQuantiles
+          summ = force $ Pure.construct qts
+      values <- genEstimatorValues n qts
+      return (summ, values)
+
+    setExportPureCounter :: Int -> IO Pure.Counter
+    setExportPureCounter n = do
+      m <- setIncrPureCounter
+      return $ force $ Pure.set (fromIntegral n) m
+
+    setExportPureHistogram :: Int -> IO Pure.Histogram
+    setExportPureHistogram n = do
+      (m, vs) <- setObservePureHistogram n
+      return $ force $ List.foldl' (flip Pure.observe) m vs
+
+    setExportPureEstimator :: Int -> IO Pure.Estimator
+    setExportPureEstimator n = do
+      (m, vs) <- setObservePureEstimator n
+      return $ force $ List.foldl' (flip Pure.observe) m vs
+
+genHistoValues :: MonadIO m => Int -> [Bucket] -> m [Double]
+genHistoValues n buckets = do
+  g <- initStdGen
+  shuffle $
+    take n $
+      Random.randomRs (0.0, 2 * last buckets) g
+
+genEstimatorValues :: MonadIO m => Int -> [Quantile] -> m [Double]
+genEstimatorValues n _qts = do
+  g <- initStdGen
+  shuffle $
+    take n $
+      Random.randoms g
+
+shuffle :: MonadIO m => [a] -> m [a]
+shuffle xs = do
+  g <- initStdGen
+  let ns = Random.randomRs (minBound :: Int, maxBound :: Int) g
+      sort' = fmap snd . List.sortBy (comparing fst)
+  return $ sort' (zip ns xs)

--- a/benchmarks/Time.hs
+++ b/benchmarks/Time.hs
@@ -1,0 +1,18 @@
+module Main where
+
+import Gauge.Main
+
+fib :: Int -> Int
+fib 0 = 0
+fib 1 = 1
+fib n = fib (n - 1) + fib (n - 2)
+
+main :: IO ()
+main =
+  defaultMain
+    [ bgroup
+        "fib"
+        [ bench "10" $ whnf fib 10,
+          bench "11" $ whnf fib 11
+        ]
+    ]

--- a/benchmarks/Time.hs
+++ b/benchmarks/Time.hs
@@ -62,7 +62,7 @@ main =
     benchObservePure setUp title =
       [ env (setUp i) $ \ ~(m, vs) ->
           bench (title ++ ": " ++ show i) $ nf (\m -> List.foldl' (flip Pure.observe) m vs) m
-        | i <- [1000, 10000]
+        | i <- [10000, 100000]
       ]
 
     benchExportPure ::
@@ -73,7 +73,7 @@ main =
     benchExportPure setUp title =
       [ env (setUp i) $ \m ->
           bench (title ++ ": " ++ show i) $ nf Pure.export m
-        | i <- [1000, 10000]
+        | i <- [10000, 100000]
       ]
 
     setIncrPureCounter :: IO Pure.Counter

--- a/prometheus-port.cabal
+++ b/prometheus-port.cabal
@@ -26,7 +26,8 @@ library
 
   hs-source-dirs: src
 
-  ghc-options:         -Wall
+  ghc-options:         -O2
+                       -Wall
                        -Wcompat
                        -Widentities
                        -Wincomplete-uni-patterns

--- a/prometheus-port.cabal
+++ b/prometheus-port.cabal
@@ -94,6 +94,7 @@ benchmark time
                , deepseq
                , gauge
                , prometheus-port
+               , random
 
   ghc-options: -O2
                -threaded

--- a/prometheus-port.cabal
+++ b/prometheus-port.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           prometheus-port
 version:        0.2.1.0
-description:    Please see the README on GitHub at <https://github.com/onramp/prometheus-port#readme>
+description:    Please see the README on GitHub at <https://github.com/on-ramp/prometheus-port#readme>
 build-type:     Simple
 
 extra-source-files: README.md
@@ -26,7 +26,36 @@ library
 
   hs-source-dirs: src
 
-  ghc-options: -O1
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Widentities
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wredundant-constraints
+                       -Wnoncanonical-monad-instances
+                       -Wno-name-shadowing
+  if impl(ghc >= 8.2)
+    ghc-options:       -fhide-source-paths
+  if impl(ghc >= 8.4)
+    ghc-options:       -Wmissing-export-lists
+                       -Wpartial-fields
+  if impl(ghc >= 8.8)
+    ghc-options:       -Wmissing-deriving-strategies
+                       -fwrite-ide-info
+                       -hiedir=.hie
+  if impl(ghc >= 8.10)
+    ghc-options:       -Wunused-packages
+  if impl(ghc >= 9.0)
+    ghc-options:       -Winvalid-haddock
+                       -Wunicode-bidirectional-format-characters
+                       -Werror=unicode-bidirectional-format-characters
+  if impl(ghc >= 9.2)
+    ghc-options:       -Wredundant-bang-patterns
+                       -Woperator-whitespace
+                       -Wimplicit-lift
+  if impl(ghc >= 9.4)
+    ghc-options:       -Wredundant-strictness-flags
+
 
   build-depends: base
                , bytestring
@@ -34,7 +63,6 @@ library
                , deepseq
                , http-types
                , stm
-               , text
                , wai
 
   default-language: Haskell2010
@@ -45,8 +73,6 @@ test-suite consistency
   main-is: Main.hs
 
   hs-source-dirs: test/consistency
-
-  ghc-options: -O1
 
   build-depends: base >=4.7 && <5
                , bytestring

--- a/prometheus-port.cabal
+++ b/prometheus-port.cabal
@@ -26,7 +26,7 @@ library
 
   hs-source-dirs: src
 
-  ghc-options:         -O2
+  ghc-options:         -O1
                        -Wall
                        -Wcompat
                        -Widentities

--- a/prometheus-port.cabal
+++ b/prometheus-port.cabal
@@ -81,3 +81,23 @@ test-suite consistency
                , prometheus-port
 
   default-language: Haskell2010
+
+benchmark time
+  type: exitcode-stdio-1.0
+
+  main-is: Time.hs
+
+  hs-source-dirs: benchmarks
+
+  build-depends: base >=4.7 && <5
+               , bytestring
+               , deepseq
+               , gauge
+               , prometheus-port
+
+  ghc-options: -O2
+               -threaded
+               -rtsopts
+               -with-rtsopts=-N
+
+  default-language: Haskell2010

--- a/src/Network/Wai/Middleware/Prometheus.hs
+++ b/src/Network/Wai/Middleware/Prometheus.hs
@@ -32,7 +32,7 @@ newtype HttpMetrics f =
 -- In order to use this, you would need to 'register' the metric.
 httpMetrics :: HttpMetrics Metric
 httpMetrics =
-  let buckets = take 14 . iterate (*2) $! 1 / 1024
+  let buckets = take 14 . iterate (*2) $ 1 / 1024
   in HttpMetrics
        { hmDuration = vector ("path", "method", "status") $
                         histogram (Info "http_req_duration" "HTTP request duration (in seconds)") buckets

--- a/src/Network/Wai/Middleware/Prometheus.hs
+++ b/src/Network/Wai/Middleware/Prometheus.hs
@@ -31,7 +31,7 @@ newtype HttpMetrics f =
 {-# NOINLINE httpMetrics #-}
 httpMetrics :: HttpMetrics Metric
 httpMetrics =
-  let buckets = take 14 . iterate (*2) $ 1 / 1024
+  let buckets = take 14 . iterate (*2) $! 1 / 1024
   in HttpMetrics
        { hmDuration = vector ("path", "method", "status") $
                         histogram (Info "http_req_duration" "HTTP request duration (in seconds)") buckets

--- a/src/Network/Wai/Middleware/Prometheus.hs
+++ b/src/Network/Wai/Middleware/Prometheus.hs
@@ -1,8 +1,14 @@
 {-# LANGUAGE DeriveGeneric
+           , DerivingStrategies
            , NumericUnderscores
            , OverloadedStrings #-}
 
-module Network.Wai.Middleware.Prometheus where
+module Network.Wai.Middleware.Prometheus
+  ( HttpMetrics(..)
+  , httpMetrics
+  , prometheus'
+  , prometheus
+  ) where
 
 import           Prometheus
 import           Type.No
@@ -10,8 +16,6 @@ import           Type.No
 import           Data.ByteString.Builder
 import qualified Data.ByteString.Lazy.Char8 as BSLC
 import           Data.Functor.Identity
-import           Data.Text.Encoding
-import           GHC.Clock
 import           GHC.Generics
 import           Network.HTTP.Types
 import           Network.Wai
@@ -22,7 +26,7 @@ newtype HttpMetrics f =
           HttpMetrics
             { hmDuration :: No Identity f (Vector3 Histogram)
             }
-          deriving Generic
+          deriving stock Generic
 
 {-# NOINLINE httpMetrics #-}
 httpMetrics :: HttpMetrics Metric
@@ -32,8 +36,6 @@ httpMetrics =
        { hmDuration = vector ("path", "method", "status") $
                         histogram (Info "http_req_duration" "HTTP request duration (in seconds)") buckets
        }
-
-
 
 prometheus'
   :: (Request -> BSLC.ByteString) -- ^ @path@

--- a/src/Prometheus.hs
+++ b/src/Prometheus.hs
@@ -77,12 +77,12 @@ import           GHC.Clock
 import           GHC.Generics
 
 
-
+-- | Exports a metric using 'template'.
 export :: Export a => a -> IO BSLC.ByteString
 export = fmap template . Base.export
 
 
-
+-- | Exports a generic metric using 'template'.
 genericExport :: (Generic (f Identity), GExport (Rep (f Identity))) => f Identity -> IO BSLC.ByteString
 genericExport = fmap (foldMap template) . Base.genericExport
 

--- a/src/Prometheus.hs
+++ b/src/Prometheus.hs
@@ -80,11 +80,13 @@ import           GHC.Generics
 -- | Exports a metric using 'template'.
 export :: Export a => a -> IO BSLC.ByteString
 export = fmap template . Base.export
+{-# INLINEABLE export #-}
 
 
 -- | Exports a generic metric using 'template'.
 genericExport :: (Generic (f Identity), GExport (Rep (f Identity))) => f Identity -> IO BSLC.ByteString
 genericExport = fmap (foldMap template) . Base.genericExport
+{-# INLINEABLE genericExport #-}
 
 
 

--- a/src/Prometheus/GHC.hs
+++ b/src/Prometheus/GHC.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric
+           , DerivingStrategies
            , OverloadedStrings #-}
 
 module Prometheus.GHC
@@ -10,13 +11,11 @@ module Prometheus.GHC
 import           Prometheus
 
 import           Control.Monad
-import qualified Data.ByteString.Lazy.Char8 as BSLC
 import           Data.Functor.Identity
 import           GHC.Generics
 import           GHC.Stats
 
 import           Type.No
-
 
 
 data RtsMetrics f =
@@ -53,7 +52,7 @@ data RtsMetrics f =
          , rmGcdetailsCpuSeconds              :: No Identity f Gauge
          , rmGcdetailsElapsedSeconds          :: No Identity f Gauge
          }
-       deriving Generic
+       deriving stock Generic
 
 rtsMetrics :: RtsMetrics Metric
 rtsMetrics =

--- a/src/Prometheus/Internal/Base.hs
+++ b/src/Prometheus/Internal/Base.hs
@@ -114,6 +114,7 @@ newtype Metric m = Metric { unMetric :: Impure (Extra m (Purify m)) (Rank m) (Pu
 -- | Appends 'Tags' to the given 'Metric'.
 tag :: Tags -> Metric metric -> Metric metric
 tag t' (Metric (Impure def (MkInfo n h t) metric)) = Metric $ Impure def (MkInfo n h $ t <> t') metric
+{-# INLINABLE tag #-}
 
 -- | Provides 'tag' for any type that derives 'Generic'.
 genericTag
@@ -122,6 +123,7 @@ genericTag
      )
   => Tags -> f Metric -> f Metric
 genericTag t = to . gtag t . from
+{-# INLINABLE genericTag #-}
 
 class GTag i where
   gtag :: Tags -> i a -> i a
@@ -187,6 +189,7 @@ genericRegister
      )
   => f Metric -> IO (f Identity)
 genericRegister = fmap to . gregister . from
+{-# INLINABLE genericRegister #-}
 
 class GRegister i o where
   gregister :: i a -> IO (o a)
@@ -219,6 +222,7 @@ genericExport
      )
   => f Identity -> IO [Template]
 genericExport = gexport . from
+{-# INLINABLE genericExport #-}
 
 class GExport i where
   gexport :: i a -> IO [Template]

--- a/src/Prometheus/Internal/Base.hs
+++ b/src/Prometheus/Internal/Base.hs
@@ -269,10 +269,20 @@ data Template = Template Info BSLC.ByteString [Sample]
 
 escape :: BSLC.ByteString -> BSLC.ByteString
 escape bs =
-  let (bef, aft) = BSLC.break (== '/') bs
+  let (bef, aft) = BSLC.break (flip elem ("\t\n\v\f\r\"\\" :: String)) bs
+
+      conv '\t' = "\\t"
+      conv '\n' = "\\n"
+      conv '\v' = "\\v"
+      conv '\f' = "\\f"
+      conv '\r' = "\\r"
+      conv '"'  = "\\\""
+      conv '\\' = "\\\\"
+      conv char = BSLC.singleton char
+
   in case BSLC.uncons aft of
        Nothing      -> bef
-       Just (_b, bs) -> "\\" <> escape bs
+       Just (b, bs) -> bef <> conv b <> escape bs
 
 template :: Template -> BSLC.ByteString
 template (Template (MkInfo name help extra) metric samples)

--- a/src/Prometheus/Internal/Primitive.hs
+++ b/src/Prometheus/Internal/Primitive.hs
@@ -2,7 +2,24 @@
            , TypeFamilies
            , ScopedTypeVariables #-}
 
-module Prometheus.Internal.Primitive where
+module Prometheus.Internal.Primitive
+  ( register_
+  , extract_
+  , export_
+  , plus_
+  , minus_
+  , set_
+  , observe_
+  , Counter(..)
+  , counter
+  , Gauge(..)
+  , gauge
+  , Histogram(..)
+  , histogram
+  , Summary(..)
+  , summary
+  ) where
+
 
 import           Prometheus.Internal.Base as Base
 import qualified Prometheus.Internal.Pure.Base as Pure
@@ -14,14 +31,12 @@ import qualified Prometheus.Internal.Pure.Summary as Pure (Quantile, Estimator, 
 import           Control.Concurrent.STM.TVar
 import           Control.DeepSeq
 import           Control.Monad.STM
-import qualified Data.ByteString.Lazy.Char8 as BSLC
 import           Data.Functor.Identity
 import           Data.Proxy
-import           System.IO.Unsafe
 
 
 register_ :: Rank a ~ Identity => Metric a -> IO (Impure () TVar (Purify a))
-register_ (Metric (Impure def info base)) = do
+register_ (Metric (Impure _def info base)) = do
   tvar <- newTVarIO $ runIdentity base
   return $ Impure () info tvar
 

--- a/src/Prometheus/Internal/Primitive.hs
+++ b/src/Prometheus/Internal/Primitive.hs
@@ -29,7 +29,6 @@ import qualified Prometheus.Internal.Pure.Histogram as Pure (Bucket, Histogram)
 import qualified Prometheus.Internal.Pure.Summary as Pure (Quantile, Estimator, Summary)
 
 import           Control.Concurrent.STM.TVar
-import           Control.DeepSeq
 import           Control.Monad.STM
 import           Data.Functor.Identity
 import           Data.Proxy
@@ -47,17 +46,17 @@ export_ :: (Pure.Name a, Pure.Export a) => Impure d TVar a -> IO Template
 export_ (Impure _ info t :: Impure d TVar a) =
   Template info (Pure.name (Proxy :: Proxy a)) . Pure.export <$> readTVarIO t
 
-plus_ :: (NFData a, Pure.Increment a) => Double -> Impure d TVar a -> IO ()
-plus_ a (Impure _ _ t) = atomically . modifyTVar' t $ force . Pure.plus a
+plus_ :: (Pure.Increment a) => Double -> Impure d TVar a -> IO ()
+plus_ a (Impure _ _ t) = atomically . modifyTVar' t $ Pure.plus a
 
-minus_ :: (NFData a, Pure.Decrement a) => Double -> Impure d TVar a -> IO ()
-minus_ a (Impure _ _ t) = atomically . modifyTVar' t $ force . Pure.minus a
+minus_ :: (Pure.Decrement a) => Double -> Impure d TVar a -> IO ()
+minus_ a (Impure _ _ t) = atomically . modifyTVar' t $ Pure.minus a
 
-set_ :: (NFData a, Pure.Set a) => Double -> Impure d TVar a -> IO ()
-set_ a (Impure _ _ t) = atomically . modifyTVar' t $ force . Pure.set a
+set_ :: (Pure.Set a) => Double -> Impure d TVar a -> IO ()
+set_ a (Impure _ _ t) = atomically . modifyTVar' t $ Pure.set a
 
-observe_ :: (NFData a, Pure.Observe a) => Double -> Impure d TVar a -> IO ()
-observe_ a (Impure _ _ t) = atomically . modifyTVar' t $ force . Pure.observe a
+observe_ :: (Pure.Observe a) => Double -> Impure d TVar a -> IO ()
+observe_ a (Impure _ _ t) = atomically . modifyTVar' t $ Pure.observe a
 
 
 

--- a/src/Prometheus/Internal/Pure/Base.hs
+++ b/src/Prometheus/Internal/Pure/Base.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE DeriveFunctor
+{-# LANGUAGE DeriveAnyClass
+           , DeriveFunctor
+           , DeriveGeneric
            , DerivingStrategies
            , FlexibleInstances
            , FunctionalDependencies
  #-}
 
 {-# OPTIONS_HADDOCK hide #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
 
 module Prometheus.Internal.Pure.Base
   ( Tags

--- a/src/Prometheus/Internal/Pure/Base.hs
+++ b/src/Prometheus/Internal/Pure/Base.hs
@@ -1,27 +1,34 @@
 {-# LANGUAGE DeriveFunctor
+           , DerivingStrategies
            , FlexibleInstances
            , FunctionalDependencies
  #-}
 
 {-# OPTIONS_HADDOCK hide #-}
 
-module Prometheus.Internal.Pure.Base where
+module Prometheus.Internal.Pure.Base
+  ( Tags
+  , Sample(..)
+  , addTags
+  , Construct(..)
+  , Name(..)
+  , Export(..)
+  , Extract(..)
+  , Increment(..)
+  , Decrement(..)
+  , Set(..)
+  , Observe(..)
+  ) where
 
 import qualified Data.ByteString.Lazy as BSL
-import           Data.Functor.Identity
-import           Data.Map (Map)
-import qualified Data.Map as Map
-import           Data.Maybe
 import           Data.Proxy
 import           Data.String
-
-
 
 type Tags = [(BSL.ByteString, BSL.ByteString)]
 
 data Sample = DoubleSample BSL.ByteString Tags Double
             | IntSample    BSL.ByteString Tags Int
-              deriving Show
+              deriving stock Show
 
 addTags :: Tags -> [Sample] -> [Sample]
 addTags = fmap . add
@@ -29,8 +36,6 @@ addTags = fmap . add
     add :: Tags -> Sample -> Sample
     add tags (DoubleSample a t d) = DoubleSample a (tags <> t) d
     add tags (IntSample    a t d) = IntSample    a (tags <> t) d
-
-
 
 class Construct c a | a -> c where
   construct :: c -> a

--- a/src/Prometheus/Internal/Pure/Base.hs
+++ b/src/Prometheus/Internal/Pure/Base.hs
@@ -5,6 +5,8 @@
  #-}
 
 {-# OPTIONS_HADDOCK hide #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
 
 module Prometheus.Internal.Pure.Base
   ( Tags
@@ -20,15 +22,18 @@ module Prometheus.Internal.Pure.Base
   , Observe(..)
   ) where
 
+import           Control.DeepSeq (NFData)
 import qualified Data.ByteString.Lazy as BSL
 import           Data.Proxy
 import           Data.String
+import           GHC.Generics (Generic)
 
 type Tags = [(BSL.ByteString, BSL.ByteString)]
 
 data Sample = DoubleSample BSL.ByteString Tags Double
             | IntSample    BSL.ByteString Tags Int
-              deriving stock Show
+              deriving stock (Show, Generic)
+              deriving anyclass (NFData)
 
 addTags :: Tags -> [Sample] -> [Sample]
 addTags = fmap . add

--- a/src/Prometheus/Internal/Pure/Base.hs
+++ b/src/Prometheus/Internal/Pure/Base.hs
@@ -30,8 +30,8 @@ import           GHC.Generics (Generic)
 
 type Tags = [(BSL.ByteString, BSL.ByteString)]
 
-data Sample = DoubleSample BSL.ByteString Tags Double
-            | IntSample    BSL.ByteString Tags Int
+data Sample = DoubleSample BSL.ByteString Tags {-# UNPACK #-}!Double
+            | IntSample    BSL.ByteString Tags {-# UNPACK #-}!Int
               deriving stock (Show, Generic)
               deriving anyclass (NFData)
 
@@ -41,6 +41,7 @@ addTags = fmap . add
     add :: Tags -> Sample -> Sample
     add tags (DoubleSample a t d) = DoubleSample a (tags <> t) d
     add tags (IntSample    a t d) = IntSample    a (tags <> t) d
+{-# INLINABLE addTags #-}
 
 class Construct c a | a -> c where
   construct :: c -> a

--- a/src/Prometheus/Internal/Pure/Counter.hs
+++ b/src/Prometheus/Internal/Pure/Counter.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE DerivingStrategies
+{-# LANGUAGE BangPatterns
+           , DerivingStrategies
            , GeneralizedNewtypeDeriving
            , MultiParamTypeClasses
            , OverloadedStrings #-}
 
 {-# OPTIONS_HADDOCK hide #-}
+{-# LANGUAGE BangPatterns #-}
 
 module Prometheus.Internal.Pure.Counter
   ( Counter(..)
@@ -20,18 +22,26 @@ newtype Counter = Counter { unCounter :: Double }
 
 instance Construct () Counter where
   construct () = Counter 0
+  {-# INLINABLE construct #-}
 
 instance Name Counter where
   name _ = "counter"
+  {-# INLINABLE name #-}
 
 instance Extract Counter Double where
   extract = unCounter
+  {-# INLINE extract #-}
 
 instance Export Counter where
   export = pure . DoubleSample "" [] . unCounter
+  {-# INLINE export #-}
 
 instance Increment Counter where
-  plus a (Counter c) = Counter $ max c (c + a)
+  plus a (Counter c) = Counter $
+    let !c' = c + a
+    in force $ max c c'
+  {-# INLINE plus #-}
 
 instance Set Counter where
-  set a (Counter c) = Counter $ max c a
+  set !a (Counter c) = Counter $ force $ max c a
+  {-# INLINE set #-}

--- a/src/Prometheus/Internal/Pure/Counter.hs
+++ b/src/Prometheus/Internal/Pure/Counter.hs
@@ -1,21 +1,22 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving
+{-# LANGUAGE DerivingStrategies
+           , GeneralizedNewtypeDeriving
            , MultiParamTypeClasses
            , OverloadedStrings #-}
 
 {-# OPTIONS_HADDOCK hide #-}
 
-module Prometheus.Internal.Pure.Counter where
+module Prometheus.Internal.Pure.Counter
+  ( Counter(..)
+  ) where
+
 
 import           Prometheus.Internal.Pure.Base
 
 import           Control.DeepSeq
-import           Data.String
-import           Data.Functor.Identity
-
 
 
 newtype Counter = Counter { unCounter :: Double }
-                  deriving NFData
+                  deriving newtype NFData
 
 instance Construct () Counter where
   construct () = Counter 0

--- a/src/Prometheus/Internal/Pure/Counter.hs
+++ b/src/Prometheus/Internal/Pure/Counter.hs
@@ -1,11 +1,9 @@
-{-# LANGUAGE BangPatterns
-           , DerivingStrategies
+{-# LANGUAGE DerivingStrategies
            , GeneralizedNewtypeDeriving
            , MultiParamTypeClasses
            , OverloadedStrings #-}
 
 {-# OPTIONS_HADDOCK hide #-}
-{-# LANGUAGE BangPatterns #-}
 
 module Prometheus.Internal.Pure.Counter
   ( Counter(..)
@@ -30,18 +28,16 @@ instance Name Counter where
 
 instance Extract Counter Double where
   extract = unCounter
-  {-# INLINE extract #-}
+  {-# INLINABLE extract #-}
 
 instance Export Counter where
   export = pure . DoubleSample "" [] . unCounter
-  {-# INLINE export #-}
+  {-# INLINABLE export #-}
 
 instance Increment Counter where
-  plus a (Counter c) = Counter $
-    let !c' = c + a
-    in force $ max c c'
-  {-# INLINE plus #-}
+  plus a (Counter c) = Counter $ max c (c + a)
+  {-# INLINABLE plus #-}
 
 instance Set Counter where
-  set !a (Counter c) = Counter $ force $ max c a
-  {-# INLINE set #-}
+  set a (Counter c) = Counter $ max c a
+  {-# INLINABLE set #-}

--- a/src/Prometheus/Internal/Pure/Gauge.hs
+++ b/src/Prometheus/Internal/Pure/Gauge.hs
@@ -1,20 +1,22 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving
+{-# LANGUAGE DerivingStrategies
+           , GeneralizedNewtypeDeriving
            , MultiParamTypeClasses
            , OverloadedStrings #-}
 
 {-# OPTIONS_HADDOCK hide #-}
 
-module Prometheus.Internal.Pure.Gauge where
+module Prometheus.Internal.Pure.Gauge
+  ( Gauge(..)
+  ) where
+
 
 import           Prometheus.Internal.Pure.Base
 
 import           Control.DeepSeq
-import           Data.String
-
 
 
 newtype Gauge = Gauge { unGauge :: Double }
-                deriving NFData
+                deriving newtype NFData
 
 instance Construct () Gauge where
   construct () = Gauge 0

--- a/src/Prometheus/Internal/Pure/Gauge.hs
+++ b/src/Prometheus/Internal/Pure/Gauge.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE BangPatterns
-           , DerivingStrategies
+{-# LANGUAGE DerivingStrategies
            , GeneralizedNewtypeDeriving
            , MultiParamTypeClasses
            , OverloadedStrings #-}
@@ -29,20 +28,20 @@ instance Name Gauge where
 
 instance Extract Gauge Double where
   extract = unGauge
-  {-# INLINE extract #-}
+  {-# INLINABLE extract #-}
 
 instance Export Gauge where
   export = pure . DoubleSample "" [] . unGauge
-  {-# INLINE export #-}
+  {-# INLINABLE export #-}
 
 instance Increment Gauge where
-  plus a = Gauge . force . (+) a . unGauge
-  {-# INLINE plus #-}
+  plus a = Gauge . (+) a . unGauge
+  {-# INLINABLE plus #-}
 
 instance Decrement Gauge where
-  minus a = Gauge . force . subtract a . unGauge
-  {-# INLINE minus #-}
+  minus a = Gauge . subtract a . unGauge
+  {-# INLINABLE minus #-}
 
 instance Set Gauge where
-  set !a = const (Gauge a)
-  {-# INLINE set #-}
+  set = const . Gauge
+  {-# INLINABLE set #-}

--- a/src/Prometheus/Internal/Pure/Gauge.hs
+++ b/src/Prometheus/Internal/Pure/Gauge.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE DerivingStrategies
+{-# LANGUAGE BangPatterns
+           , DerivingStrategies
            , GeneralizedNewtypeDeriving
            , MultiParamTypeClasses
            , OverloadedStrings #-}
@@ -20,21 +21,28 @@ newtype Gauge = Gauge { unGauge :: Double }
 
 instance Construct () Gauge where
   construct () = Gauge 0
+  {-# INLINABLE construct #-}
 
 instance Name Gauge where
   name _ = "gauge"
+  {-# INLINABLE name #-}
 
 instance Extract Gauge Double where
   extract = unGauge
+  {-# INLINE extract #-}
 
 instance Export Gauge where
   export = pure . DoubleSample "" [] . unGauge
+  {-# INLINE export #-}
 
 instance Increment Gauge where
-  plus a = Gauge . (+) a . unGauge
+  plus a = Gauge . force . (+) a . unGauge
+  {-# INLINE plus #-}
 
 instance Decrement Gauge where
-  minus a = Gauge . subtract a . unGauge
+  minus a = Gauge . force . subtract a . unGauge
+  {-# INLINE minus #-}
 
 instance Set Gauge where
-  set = const . Gauge
+  set !a = const (Gauge a)
+  {-# INLINE set #-}

--- a/src/Prometheus/Internal/Pure/Histogram.hs
+++ b/src/Prometheus/Internal/Pure/Histogram.hs
@@ -54,7 +54,7 @@ instance Construct [Bucket] Histogram where
 
 instance Extract Histogram Histogram where
   extract = id
-  {-# INLINE extract #-}
+  {-# INLINABLE extract #-}
 
 instance Export Histogram where
   export (Histogram hsum count buckets) =
@@ -77,4 +77,4 @@ instance Observe Histogram where
       case Map.lookupGE value buckets of
         Nothing         -> buckets
         Just (upper, _) -> Map.adjust (+ 1) upper buckets
-  {-# INLINE observe #-}
+  {-# INLINABLE observe #-}

--- a/src/Prometheus/Internal/Pure/Histogram.hs
+++ b/src/Prometheus/Internal/Pure/Histogram.hs
@@ -4,7 +4,12 @@
 
 {-# OPTIONS_HADDOCK hide #-}
 
-module Prometheus.Internal.Pure.Histogram where
+module Prometheus.Internal.Pure.Histogram
+  ( Bucket
+  , defBuckets
+  , Histogram(..)
+  ) where
+
 
 import           Prometheus.Internal.Pure.Base
 
@@ -12,9 +17,7 @@ import           Control.DeepSeq
 import qualified Data.ByteString.Lazy.Char8 as BSLC
 import           Data.Map (Map)
 import qualified Data.Map as Map
-import           Data.String
 import           GHC.Real
-
 
 
 type Bucket = Double
@@ -23,7 +26,6 @@ type Bucket = Double
 -- [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
 defBuckets :: [Double]
 defBuckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
-
 
 
 -- | A histogram is merely a set of buckets, each representing an upper boundary, last always

--- a/src/Prometheus/Internal/Pure/Summary.hs
+++ b/src/Prometheus/Internal/Pure/Summary.hs
@@ -69,6 +69,7 @@ data Estimator = Estimator
 
 instance NFData Estimator where
   rnf (Estimator c s q i) = rnf (c, s, q, i)
+  {-# INLINABLE rnf #-}
 
 
 -- | A summary exposes streaming φ-quantiles (0 ≤ φ ≤ 1) of observed events over a sliding time
@@ -84,6 +85,7 @@ data Summary = Summary
 
 instance NFData Summary where
   rnf (Summary c d qs) = rnf (c, d, qs)
+  {-# INLINABLE rnf #-}
 
 instance Name Estimator where
   name _ = "summary"
@@ -98,7 +100,7 @@ instance Extract Estimator Summary where
     let estimator@(Estimator count esum quantiles _) = compress estimator'
         quants = fmap fst quantiles
     in Summary (fromIntegral count) esum . zip quants $ map (query estimator) quants
-  {-# INLINE extract #-}
+  {-# INLINABLE extract #-}
 
 instance Export Estimator where
   export estimator =
@@ -106,11 +108,11 @@ instance Export Estimator where
     in converted quantiles <> [ DoubleSample "_sum" [] ssum, IntSample "_count" [] count ]
     where
       converted = fmap (\(k, a) -> DoubleSample "" [("quantile", BSLC.pack $ show k)] a)
-  {-# INLINE export #-}
+  {-# INLINABLE export #-}
 
 instance Observe Estimator where
   observe !value = insert value . compress
-  {-# INLINE observe #-}
+  {-# INLINABLE observe #-}
 
 insert :: Double -> Estimator -> Estimator
 insert value summaryData@(Estimator oldCount oldSum quantiles items) =

--- a/src/Prometheus/Internal/Pure/Summary.hs
+++ b/src/Prometheus/Internal/Pure/Summary.hs
@@ -80,6 +80,9 @@ data Summary = Summary
                  , sQuantiles :: [(Double, Double)] -- ^ [(quantile, φ-quantile)]
                  }
 
+instance NFData Summary where
+  rnf (Summary c d qs) = rnf (c, d, qs)
+
 instance Name Estimator where
   name _ = "summary"
 

--- a/src/Prometheus/Internal/Vector.hs
+++ b/src/Prometheus/Internal/Vector.hs
@@ -5,29 +5,41 @@
            , TypeFamilies
            , UndecidableInstances #-}
 
-module Prometheus.Internal.Vector where
+module Prometheus.Internal.Vector
+  ( Vector(..)
+  , vector
+  , withLabel
+  , Vector1
+  , Vector2
+  , Vector3
+  , Vector4
+  , Vector5
+  , Vector6
+  , Vector7
+  , Label1
+  , Label2
+  , Label3
+  , Label4
+  , Label5
+  , Label6
+  , Label7
+  , Zip(..)
+  ,
+  ) where
 
 import           Prometheus.Internal.Base
-import           Prometheus.Internal.Primitive
 import qualified Prometheus.Internal.Pure.Base as Pure
-import qualified Prometheus.Internal.Pure.Counter as Counter
-import qualified Prometheus.Internal.Pure.Gauge as Gauge
-import qualified Prometheus.Internal.Pure.Histogram as Histogram
-import qualified Prometheus.Internal.Pure.Summary as Summary
 
 import           Control.Concurrent.STM.TVar
 import           Control.DeepSeq
 import           Control.Monad.STM
 import qualified Data.ByteString.Lazy.Char8 as BSLC
-import           Data.Coerce
 import           Data.Functor.Compose
 import           Data.Functor.Identity
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Proxy
-import           Data.Traversable
-
 
 
 newtype Vector l s = Vector { unVector :: Impure (l, Purify s) (Compose TVar (Map l)) (Purify s) }
@@ -45,7 +57,6 @@ withLabel :: l -> Vector l s -> ((l, Vector l s) -> t) -> t
 withLabel l v a = a (l, v)
 
 
-
 type Vector1 = Vector Label1
 type Vector2 = Vector Label2
 type Vector3 = Vector Label3
@@ -54,13 +65,15 @@ type Vector5 = Vector Label5
 type Vector6 = Vector Label6
 type Vector7 = Vector Label7
 
+
 type Label1 =  BSLC.ByteString    
 type Label2 = (BSLC.ByteString, BSLC.ByteString)    
 type Label3 = (BSLC.ByteString, BSLC.ByteString, BSLC.ByteString)    
 type Label4 = (BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString)    
 type Label5 = (BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString)    
 type Label6 = (BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString)    
-type Label7 = (BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString)    
+type Label7 = (BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString)
+
     
 class Zip l where    
   zipper :: Ord l => l -> l -> Tags    
@@ -87,8 +100,7 @@ instance Zip Label7 where
   zipper (a, b, c, d, e, f, g) (n, o, p, q, r, s, t) = [(a, n), (b, o), (c, p), (d, q), (e, r), (s, f), (t, g)]
 
 
-
-instance Register s => Register (Vector l s) where
+instance Register (Vector l s) where
   register (Metric (Impure def info _)) = do
     tvar <- newTVarIO Map.empty
     return . Vector . Impure def info $ Compose tvar
@@ -105,17 +117,17 @@ instance (Zip l, Ord l, Pure.Name (Purify s), Pure.Export (Purify s)) => Export 
       f k = foldMap $ \(l, o) -> Pure.addTags (zipper k l) $ Pure.export o
 
 instance (NFData l, NFData (Purify s), Ord l, Pure.Increment (Purify s)) => Increment (l, Vector l s) where
-  plus a (l, Vector (Impure (_, def) info (Compose tvar))) =
+  plus a (l, Vector (Impure (_, def) _info (Compose tvar))) =
     atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.plus a . fromMaybe def) l
 
 instance (NFData l, NFData (Purify s), Ord l, Pure.Decrement (Purify s)) => Decrement (l, Vector l s) where
-  minus a (l, Vector (Impure (_, def) info (Compose tvar))) =
+  minus a (l, Vector (Impure (_, def) _info (Compose tvar))) =
     atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.minus a . fromMaybe def) l
 
 instance (NFData l, NFData (Purify s), Ord l, Pure.Set (Purify s)) => Set (l, Vector l s) where
-  set a (l, Vector (Impure (_, def) info (Compose tvar))) =
+  set a (l, Vector (Impure (_, def) _info (Compose tvar))) =
     atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.set a . fromMaybe def) l
 
 instance (NFData l, NFData (Purify s), Ord l, Pure.Observe (Purify s)) => Observe (l, Vector l s) where
-  observe a (l, Vector (Impure (_, def) info (Compose tvar))) =
+  observe a (l, Vector (Impure (_, def) _info (Compose tvar))) =
     atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.observe a . fromMaybe def) l

--- a/src/Prometheus/Internal/Vector.hs
+++ b/src/Prometheus/Internal/Vector.hs
@@ -24,7 +24,6 @@ module Prometheus.Internal.Vector
   , Label6
   , Label7
   , Zip(..)
-  ,
   ) where
 
 import           Prometheus.Internal.Base
@@ -42,19 +41,42 @@ import           Data.Maybe
 import           Data.Proxy
 
 
-newtype Vector l s = Vector { unVector :: Impure (l, Purify s) (Compose TVar (Map l)) (Purify s) }
+-- | Models multi-dimensional metrics shared under the same name.
+--
+-- @
+-- 'Vector Label2 Counter' corresponds to the 2-dimensional counter metric e.g. coordinates in a plane.
+-- 'Vector Label3 Counter' corresponds to the 3-dimensional counter metric e.g. coordinates in a space.
+-- @
+newtype Vector label metric = Vector { unVector :: Impure (label, Purify metric) (Compose TVar (Map label)) (Purify metric) }
 
-type instance Rank (Vector l s) = Map l
+type instance Rank (Vector label metric) = Map label
 
-type instance Purify (Vector l s) = Purify s
+type instance Purify (Vector label metric) = Purify metric
 
-type instance Extra (Vector l s) = (,) l
+type instance Extra (Vector label metric) = (,) label
 
-vector :: Extra s ~ Identity => l -> Metric s -> Metric (Vector l s)
-vector l (Metric (Impure (Identity def) info _base)) = Metric $ Impure (l, def) info Map.empty
+-- | Create a new 'Vector' of dimensions @label@ and metric @Metric metric@.
+--
+-- @
+-- let coordMetrics = vector ("x", "y") $ counter (Info "coordinates" "Coordinates counter in a 2-dimensional space")
+-- let httpMetrics = vector ("path", "method", "status") $ histogram (Info "http_req_duration" "HTTP request duration (in seconds)") buckets
+-- @
+--
+-- The constraint @Extra metric ~ Identity@ limits the @metric@ type to the primitive metrics (e.g. 'Counter', 'Histogram'...).
+vector :: (Extra metric ~ Identity) => label -> Metric metric -> Metric (Vector label metric)
+vector label (Metric (Impure (Identity def) info _base)) = Metric $ Impure (label, def) info Map.empty
 
-withLabel :: l -> Vector l s -> ((l, Vector l s) -> t) -> t
-withLabel l v a = a (l, v)
+-- | Operate on a specific metric of a 'Vector'
+--
+-- @
+-- httpMetrics :: Vector3 Histogram
+-- httpMetrics = vector ("path", "method", "status") $
+--   histogram (Info "http_req_duration" "HTTP request duration (in seconds)") buckets
+--
+-- withLabel ("/users", "GET", "200") $ observe time
+-- @
+withLabel :: label -> Vector label metric -> ((label, Vector label metric) -> t) -> t
+withLabel label v a = a (label, v)
 
 
 type Vector1 = Vector Label1
@@ -75,8 +97,8 @@ type Label6 = (BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteStrin
 type Label7 = (BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString, BSLC.ByteString)
 
     
-class Zip l where    
-  zipper :: Ord l => l -> l -> Tags    
+class Zip label where
+  zipper :: Ord label => label -> label -> Tags
     
 instance Zip Label1 where    
   zipper a n = [(a, n)]    
@@ -94,40 +116,40 @@ instance Zip Label5 where
   zipper (a, b, c, d, e) (n, o, p, q, r) = [(a, n), (b, o), (c, p), (d, q), (e, r)]    
     
 instance Zip Label6 where    
-  zipper (a, b, c, d, e, f) (n, o, p, q, r, s) = [(a, n), (b, o), (c, p), (d, q), (e, r), (s, f)]    
+  zipper (a, b, c, d, e, f) (n, o, p, q, r, metric) = [(a, n), (b, o), (c, p), (d, q), (e, r), (metric, f)]
     
 instance Zip Label7 where    
-  zipper (a, b, c, d, e, f, g) (n, o, p, q, r, s, t) = [(a, n), (b, o), (c, p), (d, q), (e, r), (s, f), (t, g)]
+  zipper (a, b, c, d, e, f, g) (n, o, p, q, r, metric, t) = [(a, n), (b, o), (c, p), (d, q), (e, r), (metric, f), (t, g)]
 
 
-instance Register (Vector l s) where
+instance Register (Vector label metric) where
   register (Metric (Impure def info _)) = do
     tvar <- newTVarIO Map.empty
     return . Vector . Impure def info $ Compose tvar
 
-instance Pure.Extract (Purify s) e => Extract (Vector l s) (Map l e) where
+instance Pure.Extract (Purify metric) e => Extract (Vector label metric) (Map label e) where
   extract (Vector (Impure _ _ (Compose tvar))) =
     fmap Pure.extract <$> readTVarIO tvar
 
-instance (Zip l, Ord l, Pure.Name (Purify s), Pure.Export (Purify s)) => Export (Vector l s) where
+instance (Zip label, Ord label, Pure.Name (Purify metric), Pure.Export (Purify metric)) => Export (Vector label metric) where
   export (Vector (Impure (tags, _) info (Compose tvar))) =
-    Template info (Pure.name (Proxy :: Proxy (Purify s))) . f tags . Map.toList <$> readTVarIO tvar
+    Template info (Pure.name (Proxy :: Proxy (Purify metric))) . f tags . Map.toList <$> readTVarIO tvar
     where
-      f :: l -> [(l, Purify s)] -> [Pure.Sample]
-      f k = foldMap $ \(l, o) -> Pure.addTags (zipper k l) $ Pure.export o
+      f :: label -> [(label, Purify metric)] -> [Pure.Sample]
+      f k = foldMap $ \(label, o) -> Pure.addTags (zipper k label) $ Pure.export o
 
-instance (NFData l, NFData (Purify s), Ord l, Pure.Increment (Purify s)) => Increment (l, Vector l s) where
-  plus a (l, Vector (Impure (_, def) _info (Compose tvar))) =
-    atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.plus a . fromMaybe def) l
+instance (NFData label, NFData (Purify metric), Ord label, Pure.Increment (Purify metric)) => Increment (label, Vector label metric) where
+  plus a (label, Vector (Impure (_, def) _info (Compose tvar))) =
+    atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.plus a . fromMaybe def) label
 
-instance (NFData l, NFData (Purify s), Ord l, Pure.Decrement (Purify s)) => Decrement (l, Vector l s) where
-  minus a (l, Vector (Impure (_, def) _info (Compose tvar))) =
-    atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.minus a . fromMaybe def) l
+instance (NFData label, NFData (Purify metric), Ord label, Pure.Decrement (Purify metric)) => Decrement (label, Vector label metric) where
+  minus a (label, Vector (Impure (_, def) _info (Compose tvar))) =
+    atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.minus a . fromMaybe def) label
 
-instance (NFData l, NFData (Purify s), Ord l, Pure.Set (Purify s)) => Set (l, Vector l s) where
-  set a (l, Vector (Impure (_, def) _info (Compose tvar))) =
-    atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.set a . fromMaybe def) l
+instance (NFData label, NFData (Purify metric), Ord label, Pure.Set (Purify metric)) => Set (label, Vector label metric) where
+  set a (label, Vector (Impure (_, def) _info (Compose tvar))) =
+    atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.set a . fromMaybe def) label
 
-instance (NFData l, NFData (Purify s), Ord l, Pure.Observe (Purify s)) => Observe (l, Vector l s) where
-  observe a (l, Vector (Impure (_, def) _info (Compose tvar))) =
-    atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.observe a . fromMaybe def) l
+instance (NFData label, NFData (Purify metric), Ord label, Pure.Observe (Purify metric)) => Observe (label, Vector label metric) where
+  observe a (label, Vector (Impure (_, def) _info (Compose tvar))) =
+    atomically . modifyTVar' tvar $ force . Map.alter (Just . Pure.observe a . fromMaybe def) label

--- a/src/Type/No.hs
+++ b/src/Type/No.hs
@@ -5,6 +5,8 @@ module Type.No
   ) where
 
 
+-- | If @f ~ m@, then @a@.
+-- Otherwise, @m a@.
 type family No m f a where
   No m m a = a
   No m f a = f a

--- a/src/Type/No.hs
+++ b/src/Type/No.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE TypeFamilies #-}
 
-module Type.No where
-
+module Type.No
+  ( No
+  ) where
 
 
 type family No m f a where


### PR DESCRIPTION
Seems to be the only part of this library working incorrectly right now.

This is obviously incompatible with the `v0.2` of the library, so I'll keep a separate branch with identical changes (current `HEAD` at 30ed260df78db803cba7f1f73193b5b735a7af5d).